### PR TITLE
Fix to Time, to ensure it always has double quotes

### DIFF
--- a/src/GitHubActionsDotNet.Tests/DependabotTests.cs
+++ b/src/GitHubActionsDotNet.Tests/DependabotTests.cs
@@ -42,7 +42,7 @@ updates:
   directory: /
   schedule:
     interval: daily
-    time: 06:00
+    time: ""06:00""
     timezone: America/New_York
   assignees:
   - samsmithnz
@@ -51,7 +51,7 @@ updates:
   directory: /
   schedule:
     interval: daily
-    time: 06:00
+    time: ""06:00""
     timezone: America/New_York
   assignees:
   - samsmithnz

--- a/src/GitHubActionsDotNet/Models/Dependabot/Schedule.cs
+++ b/src/GitHubActionsDotNet/Models/Dependabot/Schedule.cs
@@ -1,8 +1,12 @@
-﻿namespace GitHubActionsDotNet.Models.Dependabot
+﻿using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace GitHubActionsDotNet.Models.Dependabot
 {
     public class Schedule
     {
         public string interval { get; set; }
+        [YamlMember(ScalarStyle = ScalarStyle.DoubleQuoted)]
         public string time { get; set; }
         public string timezone { get; set; }
     }


### PR DESCRIPTION
The problem, in Dependabot, the time is stored as:
```
time: 6:00
```

If it doesn't serialize with quotes, the Dependabot file can't be processed. Therefore, updated the model to always wrap this value in double quotes:
```
time: "6:00"
```
