### PR TITLE
Adding permissions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -25,12 +25,12 @@ jobs:
         
     #Install and calculate the new version with GitVersion  
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v4.2.0
+      uses: gittools/actions/gitversion/setup@v4.3.0
       with:
         versionSpec: 6.x
 
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v4.2.0
+      uses: gittools/actions/gitversion/execute@v4.3.0
       id: gitversion # step id used as reference for output values
 
     - name: Display GitVersion outputs

--- a/src/GitHubActionsDotNet.Tests/CompletePipelineTest.cs
+++ b/src/GitHubActionsDotNet.Tests/CompletePipelineTest.cs
@@ -158,5 +158,107 @@ jobs:
         expected = UtilityTests.TrimNewLines(expected);
         Assert.AreEqual(expected, yaml);
     }
+
+    [TestMethod]
+    public void WorkflowWithTopLevelPermissionsTest()
+    {
+        //Arrange
+        JobHelper jobHelper = new();
+        GitHubActionsRoot root = new()
+        {
+            name = "CI",
+            on = TriggerHelper.AddStandardPushAndPullTrigger(),
+            permissions = new Permissions
+            {
+                contents = "read",
+                packages = "write"
+            },
+            jobs = new()
+        };
+        Step[] buildSteps = new Step[] {
+            CommonStepHelper.AddCheckoutStep(),
+        };
+        Job buildJob = jobHelper.AddJob(
+            null,
+            "ubuntu-latest",
+            buildSteps);
+        root.jobs.Add("build", buildJob);
+
+        //Act
+        string yaml = Serialization.GitHubActionsSerialization.Serialize(root);
+
+        //Assert
+        string expected = @"
+name: CI
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+";
+        expected = UtilityTests.TrimNewLines(expected);
+        Assert.AreEqual(expected, yaml);
+    }
+
+    [TestMethod]
+    public void JobWithPermissionsTest()
+    {
+        //Arrange
+        JobHelper jobHelper = new();
+        GitHubActionsRoot root = new()
+        {
+            name = "CI",
+            on = TriggerHelper.AddStandardPushAndPullTrigger(),
+            jobs = new()
+        };
+        Step[] buildSteps = new Step[] {
+            CommonStepHelper.AddCheckoutStep(),
+        };
+        Job buildJob = jobHelper.AddJob(
+            null,
+            "ubuntu-latest",
+            buildSteps);
+        buildJob.permissions = new Permissions
+        {
+            issues = "write",
+            pull_requests = "write"
+        };
+        root.jobs.Add("stale", buildJob);
+
+        //Act
+        string yaml = Serialization.GitHubActionsSerialization.Serialize(root);
+
+        //Assert
+        string expected = @"
+name: CI
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+";
+        expected = UtilityTests.TrimNewLines(expected);
+        Assert.AreEqual(expected, yaml);
+    }
 }
 

--- a/src/GitHubActionsDotNet.Tests/GitHubActionsDotNet.Tests.csproj
+++ b/src/GitHubActionsDotNet.Tests/GitHubActionsDotNet.Tests.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitHubActionsDotNet/GitHubActionsDotNet.csproj
+++ b/src/GitHubActionsDotNet/GitHubActionsDotNet.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.IO" Version="4.3.0" />
-		<PackageReference Include="System.Text.Json" Version="10.0.2" />
+		<PackageReference Include="System.Text.Json" Version="10.0.3" />
 		<PackageReference Include="YamlDotNet" Version="16.3.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />	
 	</ItemGroup>

--- a/src/GitHubActionsDotNet/Models/GitHubActionsRoot.cs
+++ b/src/GitHubActionsDotNet/Models/GitHubActionsRoot.cs
@@ -7,6 +7,7 @@ namespace GitHubActionsDotNet.Models
     {
         public string name { get; set; }
         public Trigger on { get; set; }
+        public Permissions permissions { get; set; }
         public Dictionary<string, string> env { get; set; }
         public Dictionary<string, Job> jobs { get; set; }
 

--- a/src/GitHubActionsDotNet/Models/Job.cs
+++ b/src/GitHubActionsDotNet/Models/Job.cs
@@ -5,6 +5,7 @@ namespace GitHubActionsDotNet.Models
     public class Job
     {
         public string name { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idname
+        public Permissions permissions { get; set; } //https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions
         public Strategy strategy { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstrategy
         public string runs_on { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idruns-on
         //public T container { get; set; }

--- a/src/GitHubActionsDotNet/Models/Job.cs
+++ b/src/GitHubActionsDotNet/Models/Job.cs
@@ -5,9 +5,9 @@ namespace GitHubActionsDotNet.Models
     public class Job
     {
         public string name { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idname
-        public Permissions permissions { get; set; } //https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions
         public Strategy strategy { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstrategy
         public string runs_on { get; set; } //https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idruns-on
+        public Permissions permissions { get; set; } //https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions
         //public T container { get; set; }
         public Dictionary<string, string> outputs { get; set; } //https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idoutputs
         public Container container { get; set; } //https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schemaview=azure-devops&tabs=schema#job

--- a/src/GitHubActionsDotNet/Models/Permissions.cs
+++ b/src/GitHubActionsDotNet/Models/Permissions.cs
@@ -1,0 +1,20 @@
+namespace GitHubActionsDotNet.Models
+{
+    public class Permissions
+    {
+        public string actions { get; set; }
+        public string attestations { get; set; }
+        public string checks { get; set; }
+        public string contents { get; set; }
+        public string deployments { get; set; }
+        public string discussions { get; set; }
+        public string id_token { get; set; }
+        public string issues { get; set; }
+        public string models { get; set; }
+        public string packages { get; set; }
+        public string pages { get; set; }
+        public string pull_requests { get; set; }
+        public string security_events { get; set; }
+        public string statuses { get; set; }
+    }
+}

--- a/src/GitHubActionsDotNet/Serialization/GitHubActionsSerialization.cs
+++ b/src/GitHubActionsDotNet/Serialization/GitHubActionsSerialization.cs
@@ -104,6 +104,9 @@ namespace GitHubActionsDotNet.Serialization
             yaml = yaml.Replace("ref", "_ref");
             yaml = yaml.Replace("continue-on-error", "continue_on_error");
             yaml = yaml.Replace("timeout-minutes", "timeout_minutes");
+            yaml = yaml.Replace("id-token", "id_token");
+            yaml = yaml.Replace("pull-requests", "pull_requests");
+            yaml = yaml.Replace("security-events", "security_events");
 
             return YamlSerialization.DeserializeYaml<GitHubActionsRoot>(yaml);
         }
@@ -124,6 +127,9 @@ namespace GitHubActionsDotNet.Serialization
             yaml = yaml.Replace("continue_on_error", "continue-on-error");
             yaml = yaml.Replace("timeout_minutes", "timeout-minutes");
             yaml = yaml.Replace("_default", "default");
+            yaml = yaml.Replace("id_token", "id-token");
+            yaml = yaml.Replace("pull_requests", "pull-requests");
+            yaml = yaml.Replace("security_events", "security-events");
             yaml = yaml.Replace("step_message:", "#");
             yaml = yaml.Replace("job_message:", "#");
             yaml = yaml.Replace("step_message", "#");


### PR DESCRIPTION
This pull request adds support for the `permissions` property at both the workflow and job levels in GitHub Actions YAML serialization and deserialization. It introduces a new `Permissions` model, updates the serialization logic to handle property name mappings for permissions, and adds comprehensive tests to ensure correct YAML output. Additionally, it updates several package dependencies.

fixes #237 